### PR TITLE
Add Gemfile.lock to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ test/dummy/db/*.sqlite3-journal
 test/dummy/log/*.log
 test/dummy/tmp/
 test/dummy/.sass-cache
+Gemfile.lock


### PR DESCRIPTION
`Gemfile.lock` shouldn't be committed so it makes sense to add it to `.gitignore`.