### PR TITLE
Loads config from yaml file if present

### DIFF
--- a/lib/generators/favicon_generator.rb
+++ b/lib/generators/favicon_generator.rb
@@ -10,7 +10,11 @@ class FaviconGenerator < Rails::Generators::Base
   PATH_UNIQUE_KEY = 'Dfv87ZbNh2'
 
   def generate_favicon
-    req = JSON.parse File.read('config/favicon.json')
+    if File.exist?('config/favicon.yml') && defined?(Rails.application.config_for)
+      req = Rails.application.config_for(:favicon)
+    else
+      req = JSON.parse File.read('config/favicon.json')
+    end
 
     req['api_key'] = API_KEY
 


### PR DESCRIPTION
If `config/favicon.yml` is present, and `Rails.application.config_for` is defined (>= 4.2), then this will prefer that file over `config/favicon.json`, as it conforms better to Rails best-practices, and allows for ERB templating.

I have a use-case where I want to use a different file for the master image based on an environment variable, and using ERb inside Yaml is a common practice (which is supported by config_for), whereas trying to add templating to the json file felt hacky, so this felt like an addition that others could benefit from.