### PR TITLE
site.manifest file is not updated

### DIFF
--- a/lib/generators/favicon_generator.rb
+++ b/lib/generators/favicon_generator.rb
@@ -35,7 +35,7 @@ class FaviconGenerator < Rails::Generators::Base
       Dir["#{tmp_dir}/*.*"].each do |file|
         content = File.binread(file)
         new_ext = ''
-        if File.extname(file) == '.json' or File.extname(file) == '.xml'
+        if %w{.json .xml .webmanifest}.include? File.extname(file)
           content = replace_url_by_asset_path content
           new_ext = '.erb'
         end

--- a/lib/rails_real_favicon/version.rb
+++ b/lib/rails_real_favicon/version.rb
@@ -1,3 +1,3 @@
 module RailsRealFavicon
-  VERSION = "0.0.7"
+  VERSION = "0.0.8"
 end


### PR DESCRIPTION
The site.manifest file downloaded from but not updated with the proper resources paths.
A trivial fix adding .webmanifest extension to the list of file for which to generate ERB.