### PR TITLE
replace rest-client with ruby net/http, to remove a dependency

### DIFF
--- a/rails_real_favicon.gemspec
+++ b/rails_real_favicon.gemspec
@@ -18,7 +18,6 @@ Gem::Specification.new do |s|
   s.test_files = Dir["test/**/*"]
 
   s.add_dependency "rails", ">= 3.1"
-  s.add_dependency "rest-client", "~> 2.0"
   s.add_dependency "json", ">= 1.7", "< 3"
   s.add_dependency "rubyzip", "~> 1"
 end


### PR DESCRIPTION
In order to remove the rest-client dependency (for just one single post request and in one of my project it caused some issues), I added a version with net/http ruby and removed rest-cilent.

Tests passed, so I do not expect a problem with this change.